### PR TITLE
Fix build issues on Ubuntu

### DIFF
--- a/src/settings/shortcuts.rs
+++ b/src/settings/shortcuts.rs
@@ -58,13 +58,17 @@ pub struct ShortcutMap {
 impl Default for ShortcutMap {
 	fn default() -> Self {
 		#[cfg(target_os = "macos")]
-		return Self { look: "cmd+v".into(), autocomplete: "cmd+a".into(), hear: "cmd+h".into() };
-
-		#[cfg(any(target_os = "windows", target_os = "linux"))]
-		return Self { look: "ctrl+v".into(), autocomplete: "ctrl+a".into(), hear: "ctrl+h".into() };
-
+		{
+			return Self { look: "cmd+v".into(), autocomplete: "cmd+a".into(), hear: "cmd+h".into() };
+		}
+		#[cfg(target_os = "windows")]
+		{
+			return Self { look: "ctrl+v".into(), autocomplete: "ctrl+a".into(), hear: "ctrl+h".into() };
+		}
 		#[cfg(target_os = "linux")]
-		return Self { look: "ctrl+v".into(), autocomplete: "ctrl+a".into(), hear: "ctrl+h".into() };
+		{
+			return Self { look: "ctrl+v".into(), autocomplete: "ctrl+a".into(), hear: "ctrl+h".into() };
+		}
 	}
 }
 


### PR DESCRIPTION
> [!WARNING]
> I do not have a MacBook, so you should checkout this PR and test on macOS to ensure that functionality is still fine on macOS.

I fixed Rust build errors on Ubuntu. Ubuntu handles X11 differently than macOS, causing 9 errors in `cargo check`.
I can't guarantee that my changes won't break macOS. If they do, please let me know, and I'll update the code to only apply my changes on Linux (with cfg target).